### PR TITLE
Import reallocarray implementation from OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,23 @@
 CC?=clang
-YC?=yacc
+YACC?=yacc
 BIN=doas
 PREFIX?=/usr/local
 OBJECTS=doas.o env.o execvpe.o reallocarray.o y.tab.o
-CFLAG+= -DUSE_PAM
-LFLAG+= -lpam
+CFLAGS+=-DUSE_PAM
+LDFLAGS+=-lpam
 
 all: $(OBJECTS)
-	$(CC) -o $(BIN) $(LFLAG) $(OBJECTS)
+	$(CC) -o $(BIN) $(LDFLAGS) $(OBJECTS)
 
-env.o: doas.h env.c 
-	$(CC) -c env.c 
+env.o: doas.h env.c
 
 execvpe.o: doas.h execvpe.c
-	$(CC) -c execvpe.c
 
 doas.o: doas.h doas.c parse.y
-	$(CC) $(CFLAG) -c doas.c
 
 y.tab.o: parse.y
-	$(YC) parse.y
-	$(CC) -c y.tab.c
+	$(YACC) parse.y
+	$(CC) $(CFLAGS) -c y.tab.c
 
 install: all
 	cp $(BIN) $(PREFIX)/bin/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ YACC?=yacc
 BIN=doas
 PREFIX?=/usr/local
 OBJECTS=doas.o env.o execvpe.o reallocarray.o y.tab.o
-CFLAGS+=-DUSE_PAM
+CFLAGS+=-DUSE_PAM -DDOAS_CONF=\"${PREFIX}/etc/doas.conf\"
 LDFLAGS+=-lpam
 
 all: $(OBJECTS)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC?=clang
 YC?=yacc
 BIN=doas
 PREFIX?=/usr/local
-OBJECTS=doas.o env.o execvpe.o y.tab.o
+OBJECTS=doas.o env.o execvpe.o reallocarray.o y.tab.o
 CFLAG+= -DUSE_PAM
 LFLAG+= -lpam
 

--- a/doas.c
+++ b/doas.c
@@ -324,7 +324,7 @@ main(int argc, char **argv)
 	int pam_silent = PAM_SILENT;
 #endif
 
-	parseconfig("/usr/local/etc/doas.conf", 1);
+	parseconfig(DOAS_CONF, 1);
 
 	/* cmdline is used only for logging, no need to abort on truncate */
 	(void) strlcpy(cmdline, argv[0], sizeof(cmdline));

--- a/doas.h
+++ b/doas.h
@@ -27,11 +27,7 @@ char **prepenv(struct rule *);
 #define _PW_NAME_LEN 32
 #endif
 
-#if !defined(HAVE_REALLOCARRAY) && !defined(HAVE_REALLOCARR)
-int reallocarr(void *ptr, size_t num, size_t size);
-#endif	/* !HAVE_REALLOCARRAY && !HAVE_REALLOCARR */
-
-
+void *reallocarray(void *ptr, size_t nmemb, size_t size);
 
 #if !defined(HAVE_EXECVPE)
 int execvpe(const char *file, char * const *argv, char * const *envp);

--- a/env.c
+++ b/env.c
@@ -95,7 +95,7 @@ flattenenv(struct env *env)
 	struct envnode *node;
 	u_int i;
 
-        envp = realloc(NULL, (env->count + 1) * sizeof(char *));
+        envp = reallocarray(NULL, (env->count + 1), sizeof(char *));
 	if (!envp)
 		err(1, NULL);
 	i = 0;

--- a/parse.y
+++ b/parse.y
@@ -84,10 +84,8 @@ rule:		action ident target cmd {
 					maxrules = 63;
 				else
 					maxrules *= 2;
-				/* if (!(rules = reallocarray(rules, maxrules,
+				if (!(rules = reallocarray(rules, maxrules,
 				    sizeof(*rules))))
-                                */
-                                if (!(rules = realloc(rules, maxrules * sizeof(*rules))))
 					errx(1, "can't allocate rules");
 			}
 			rules[nrules++] = r;
@@ -127,10 +125,8 @@ envlist:	/* empty */ {
 				errx(1, "can't allocate envlist");
 		} | envlist TSTRING {
 			int nenv = arraylen($1.envlist);
-			/* if (!($$.envlist = reallocarray($1.envlist, nenv + 2,
+			if (!($$.envlist = reallocarray($1.envlist, nenv + 2,
 			    sizeof(char *))))
-                        */
-                        if (!($$.envlist = realloc($1.envlist, (nenv + 2) * sizeof(char*))))
 				errx(1, "can't allocate envlist");
 			$$.envlist[nenv] = $2.str;
 			$$.envlist[nenv + 1] = NULL;
@@ -166,10 +162,8 @@ argslist:	/* empty */ {
 				errx(1, "can't allocate args");
 		} | argslist TSTRING {
 			int nargs = arraylen($1.cmdargs);
-			/* if (!($$.cmdargs = reallocarray($1.cmdargs, nargs + 2,
+			if (!($$.cmdargs = reallocarray($1.cmdargs, nargs + 2,
 			    sizeof(char *))))
-                        */
-                         if (!($$.cmdargs = realloc($1.cmdargs, (nargs + 2) * sizeof(char *))))
 				errx(1, "can't allocate args");
 			$$.cmdargs[nargs] = $2.str;
 			$$.cmdargs[nargs + 1] = NULL;

--- a/reallocarray.c
+++ b/reallocarray.c
@@ -1,0 +1,39 @@
+/*	$OpenBSD: reallocarray.c,v 1.3 2015/09/13 08:31:47 guenther Exp $	*/
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+void *
+reallocarray(void *optr, size_t nmemb, size_t size)
+{
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(optr, size * nmemb);
+}
+DEF_WEAK(reallocarray);

--- a/reallocarray.c
+++ b/reallocarray.c
@@ -36,4 +36,4 @@ reallocarray(void *optr, size_t nmemb, size_t size)
 	}
 	return realloc(optr, size * nmemb);
 }
-DEF_WEAK(reallocarray);
+//DEF_WEAK(reallocarray);


### PR DESCRIPTION
Thanks for porting doas. I've just uninstalled sudo on my FreeBSD desktop :-)

I've imported reallocarray.c from OpenBSD and changed realloc back to reallocarray. I hope this is ok with you and not seen as too much bike shedding. 

Currently the Makefile does not respect settings from the environment like CFLAGS, LDFLAGS, and YACC so I fixed this too.

I've also applied the 2 local patches that are now in the FreeBSD ports tree.

Let me know what you think.