### PR TITLE
Use setusercontext on FreeBSD 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
     LDFLAGS+=-lpam_misc
 endif
+ifeq ($(UNAME_S),FreeBSD)
+    CFLAGS+=-DHAVE_LOGIN_CAP_H
+    LDFLAGS+=-lutil
+endif
 
 all: $(OBJECTS)
 	$(CC) -o $(BIN) $(LDFLAGS) $(OBJECTS)

--- a/doas.c
+++ b/doas.c
@@ -530,12 +530,14 @@ main(int argc, char **argv)
         }
         #endif
 
+#ifndef HAVE_LOGIN_CAP_H
         /* If we effectively are root, set the UID to actually be root to avoid
            permission errors. */
         if (target != 0)
            setuid(target);
         if ( geteuid() == ROOT_UID )
            setuid(ROOT_UID);
+#endif
 
 	syslog(LOG_AUTHPRIV | LOG_INFO, "%s ran command %s as %s from %s",
 	    myname, cmdline, pw->pw_name, cwd);


### PR DESCRIPTION
… and get rid of the geteuid/setuid workaround

Currently HAVE_LOGIN_CAP_H is never defined even though it's available on FreeBSD. By using `setusercontext` we don't need to manually set the uid. `LOGIN_SETUSER` and `LOGIN_SETGROUP` takes care of this.

Without this running e.g. `doas -u _sndio id` returns:
```
uid=702(_sndio) gid=702(_sndio) egid=1001(tobias) groups=1001(tobias),0(wheel),5(operator),68(dialer),145(webcamd),920(vboxusers),1002(users)
```
i.e. the effective gid is still wrong and we have more permissions that we should have. With `setusercontext` we get a much saner (mirroring `sudo -u _sndio id`):
```
uid=702(_sndio) gid=702(_sndio) groups=702(_sndio)
```