### PR TITLE
Workaround for issue #3: hide stdin from openpam_ttyconv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(UNAME_S),FreeBSD)
 endif
 
 all: $(OBJECTS)
-	$(CC) -o $(BIN) $(LDFLAGS) $(OBJECTS)
+	$(CC) -o $(BIN) $(OBJECTS) $(LDFLAGS)
 
 env.o: doas.h env.c
 

--- a/doas.c
+++ b/doas.c
@@ -278,9 +278,6 @@ main(int argc, char **argv)
 	const char *cwd;
 	char *login_style = NULL;
 	char **envp;
-        #ifdef USE_PAM
-        int temp_stdout;
-        #endif
 
         #ifndef linux
 	setprogname("doas");
@@ -360,12 +357,6 @@ main(int argc, char **argv)
 		exit(1);	/* fail safe */
 	}
 
-#if defined(USE_PAM)
-	pam_handle_t *pamh = NULL;
-	int pam_err;
-	int pam_silent = PAM_SILENT;
-#endif
-
 	parseconfig(DOAS_CONF, 1);
 
 	/* cmdline is used only for logging, no need to abort on truncate */
@@ -433,11 +424,25 @@ main(int argc, char **argv)
 	pam_end(pamh, pam_err);						\
 	exit(EXIT_FAILURE);						\
 } while (/*CONSTCOND*/0)
+		pam_handle_t *pamh = NULL;
+		int pam_err;
+		int temp_stdin;
 
-                /* force password prompt to display on stderr, not stdout */
-                temp_stdout = dup(1);
-                close(1);
-                dup2(2, 1);
+		/* openpam_ttyconv checks if stdin is a terminal and
+		 * if it is then does not bother to open /dev/tty.
+		 * The result is that PAM writes the password prompt
+		 * directly to stdout.  In scenarios where stdin is a
+		 * terminal, but stdout is redirected to a file
+		 * e.g. by running doas ls &> ls.out interactively,
+		 * the password prompt gets written to ls.out as well.
+		 * By closing stdin first we forces PAM to read/write
+		 * to/from the terminal directly.  We restore stdin
+		 * after authenticating. */
+		temp_stdin = dup(STDIN_FILENO);
+		if (temp_stdin == -1)
+			err(1, "dup");
+		close(STDIN_FILENO);
+
 		pam_err = pam_start("doas", myname, &pamc, &pamh);
 		if (pam_err != PAM_SUCCESS) {
 			if (pamh != NULL)
@@ -447,15 +452,15 @@ main(int argc, char **argv)
 			errx(EXIT_FAILURE, "pam_start failed");
 		}
 
-		switch (pam_err = pam_authenticate(pamh, pam_silent)) {
+		switch (pam_err = pam_authenticate(pamh, PAM_SILENT)) {
 		case PAM_SUCCESS:
-			switch (pam_err = pam_acct_mgmt(pamh, pam_silent)) {
+			switch (pam_err = pam_acct_mgmt(pamh, PAM_SILENT)) {
 			case PAM_SUCCESS:
 				break;
 
 			case PAM_NEW_AUTHTOK_REQD:
 				pam_err = pam_chauthtok(pamh,
-				    pam_silent|PAM_CHANGE_EXPIRED_AUTHTOK);
+				    PAM_SILENT|PAM_CHANGE_EXPIRED_AUTHTOK);
 				if (pam_err != PAM_SUCCESS)
 					PAM_END("pam_chauthtok");
 				break;
@@ -487,6 +492,11 @@ main(int argc, char **argv)
 			break;
 		}
 		pam_end(pamh, pam_err);
+
+		/* Re-establish stdin */
+		if (dup2(temp_stdin, STDIN_FILENO) == -1)
+			err(1, "dup2");
+		close(temp_stdin);
 #else
 #error	No auth module!
 #endif
@@ -521,15 +531,6 @@ main(int argc, char **argv)
         if (pledge("stdio exec", NULL) == -1)
 		err(1, "pledge");
         */
-        /* Re-establish stdout */
-        #ifdef USE_PAM
-        if (!(rule->options & NOPASS))
-        {
-          close(1);
-          dup2(temp_stdout, 1);
-        }
-        #endif
-
 #ifndef HAVE_LOGIN_CAP_H
         /* If we effectively are root, set the UID to actually be root to avoid
            permission errors. */


### PR DESCRIPTION
Continuing on from issue #3. This time with code that fixes it.

`sudo`'s password prompt normally goes directly to the terminal device as is documented in sudo(8):
```
     -S, --stdin
                 Write the prompt to the standard error and read the password
                 from the standard input instead of using the terminal device.
                 The password must be followed by a newline character.
```
That doas on FreeBSD currently pushes the password prompt to `stderr` is a bug. Even more so when using redirects and when it ends up in the file.

`doas ls &> ls.out` currently behaves like `sudo -S ls &> ls.out` on FreeBSD which is a departure from OpenBSD. 

On an OpenBSD 6.0 system (using bash for `&>`) compare (1) `doas ls &> ls.out` and (2) `sudo ls &> ls.out` and (3) `sudo -S ls &> ls.out`. In case (1)+(2) `ls.out` will NOT contain the password prompt. Only in case (3) it will.

sudo has its own conversation function and the problem in doas is `openpam_ttyconv`. `openpam_ttyconv` checks if `stdin` is a terminal using `isatty(3)` and if it is then does not bother to open `/dev/tty` [1].  The result is that PAM writes the password prompt directly to `stdout` (without your `stderr`/`stdout` dup-fix in place).  In scenarios where `stdin` is a terminal, but `stdout` is redirected to a file e.g. by running `doas ls &> ls.out` interactively, the password prompt gets written to `ls.out` as well.  By closing `stdin` first we force PAM to read/write to/from the terminal directly.  We restore `stdin` after authenticating.

[1] https://github.com/freebsd/freebsd/blob/master/contrib/openpam/lib/libpam/openpam_ttyconv.c#L293