### PR TITLE
Add support for building doas on macOS Catalina

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ ifeq ($(UNAME_S),SunOS)
     COMPAT=errc.o pm_pam_conv.o setresuid.o verrc.o
     OBJECTS+=$(COMPAT:%.o=compat/%.o)
 endif
+ifeq ($(UNAME_S),Darwin)
+    CPPFLAGS+=-Icompat
+    COMPAT+=bsd-closefrom.o
+    OBJECTS+=$(COMPAT:%.o=compat/%.o)
+    # On MacOS the default man page path is /usr/local/share/man
+    MANDIR=$(DESTDIR)$(PREFIX)/share/man
+endif
 
 all: $(OBJECTS)
 	$(CC) -o $(BIN) $(OBJECTS) $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installing doas is accomplished in three steps:
 
 ## Installing build tools
 
-1 - The doas program has virtually no dependencies. So long as you have a compiler (such as the GNU Compiler or Clang) installed and GNU make (gmake on NetBSD, FreeBSD, and illumos). On illumos, the build-essential package will install all the necessary build tools. Linux may need libpam headers to compile which can be added with the libpam0g-dev package on Debian/Ubuntui. On macOS an installation of XCode is necessary, due to the missing cli development tools in the default installation.
+1 - The doas program has virtually no dependencies. So long as you have a compiler (such as the GNU Compiler or Clang) installed and GNU make (gmake on NetBSD, FreeBSD, and illumos). On illumos, the build-essential package will install all the necessary build tools. Linux may need libpam headers to compile which can be added with the libpam0g-dev package on Debian/Ubuntu. On macOS an installation of XCode is necessary, due to the missing cli development tools in the default installation.
 
 ## Compiling and installing
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # doas
-A port of OpenBSD's doas which runs on FreeBSD, Linux, NetBSD, and illumos
+A port of OpenBSD's doas which runs on FreeBSD, Linux, NetBSD, illumos and macOS.
 
 The doas utility is a program originally written for OpenBSD which allows a user to run a command as though they were another user. Typically doas is used to allow non-privleged users to run commands as though they were the root user. The doas program acts as an alternative to sudo, which is a popular method in the Linux community for granting admin access to specific users.
 
 The doas program offers two benefits over sudo: its configuration file has a simple syntax and it is smaller, requiring less effort to audit the code. This makes it harder for both admins and coders to make mistakes that potentially open security holes in the system.
 
-This port of doas has been made to work on FreeBSD 11.x and newer, most distributions of Linux, NetBSD 8.x and newer, and most illumos distributions (tested on OmniOS and SmartOS).
+This port of doas has been made to work on FreeBSD 11.x and newer, most distributions of Linux, NetBSD 8.x and newer, and most illumos distributions (tested on OmniOS and SmartOS). It also works on macOS Catalina.
 
 Installing doas is accomplished in three steps:
 1. Installing build tools.
@@ -14,7 +14,7 @@ Installing doas is accomplished in three steps:
 
 ## Installing build tools
 
-1 - The doas program has virtually no dependencies. So long as you have a compiler (such as the GNU Compiler or Clang) installed and GNU make (gmake on NetBSD, FreeBSD, and illumos). On illumos, the build-essential package will install all the necessary build tools. Linux may need libpam headers to compile which can be added with the libpam0g-dev package on Debian/Ubuntu.
+1 - The doas program has virtually no dependencies. So long as you have a compiler (such as the GNU Compiler or Clang) installed and GNU make (gmake on NetBSD, FreeBSD, and illumos). On illumos, the build-essential package will install all the necessary build tools. Linux may need libpam headers to compile which can be added with the libpam0g-dev package on Debian/Ubuntui. On macOS an installation of XCode is necessary, due to the missing cli development tools in the default installation.
 
 ## Compiling and installing
 
@@ -24,7 +24,7 @@ Installing doas is accomplished in three steps:
 
      make
     
-#### FreeBSD and NetBSD
+#### FreeBSD, NetBSD and macOS
 
      gmake
 
@@ -42,7 +42,7 @@ This builds the source code. Then, as the root user, run
 
      make install
 
-#### FreeBSD and NetBSD
+#### FreeBSD, NetBSD and macOS
 
      gmake install
 

--- a/compat/bsd-closefrom.c
+++ b/compat/bsd-closefrom.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2004-2005 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+// #include "includes.h"
+
+#ifndef HAVE_CLOSEFROM
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <unistd.h>
+#include <stdio.h>
+#ifdef HAVE_FCNTL_H
+# include <fcntl.h>
+#endif
+#include <limits.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <unistd.h>
+#ifdef HAVE_DIRENT_H
+# include <dirent.h>
+# define NAMLEN(dirent) strlen((dirent)->d_name)
+#else
+# define dirent direct
+# define NAMLEN(dirent) (dirent)->d_namlen
+# ifdef HAVE_SYS_NDIR_H
+#  include <sys/ndir.h>
+# endif
+# ifdef HAVE_SYS_DIR_H
+#  include <sys/dir.h>
+# endif
+# ifdef HAVE_NDIR_H
+#  include <ndir.h>
+# endif
+#endif
+#if defined(HAVE_LIBPROC_H)
+# include <libproc.h>
+#endif
+
+#ifndef OPEN_MAX
+# define OPEN_MAX	256
+#endif
+
+#if 0
+__unused static const char rcsid[] = "$Sudo: closefrom.c,v 1.11 2006/08/17 15:26:54 millert Exp $";
+#endif /* lint */
+
+#ifndef HAVE_FCNTL_CLOSEM
+/*
+ * Close all file descriptors greater than or equal to lowfd.
+ */
+static void
+closefrom_fallback(int lowfd)
+{
+	long fd, maxfd;
+
+	/*
+	 * Fall back on sysconf() or getdtablesize().  We avoid checking
+	 * resource limits since it is possible to open a file descriptor
+	 * and then drop the rlimit such that it is below the open fd.
+	 */
+#ifdef HAVE_SYSCONF
+	maxfd = sysconf(_SC_OPEN_MAX);
+#else
+	maxfd = getdtablesize();
+#endif /* HAVE_SYSCONF */
+	if (maxfd < 0)
+		maxfd = OPEN_MAX;
+
+	for (fd = lowfd; fd < maxfd; fd++)
+		(void) close((int) fd);
+}
+#endif /* HAVE_FCNTL_CLOSEM */
+
+#ifdef HAVE_FCNTL_CLOSEM
+void
+closefrom(int lowfd)
+{
+    (void) fcntl(lowfd, F_CLOSEM, 0);
+}
+#elif defined(HAVE_LIBPROC_H) && defined(HAVE_PROC_PIDINFO)
+void
+closefrom(int lowfd)
+{
+	int i, r, sz;
+	pid_t pid = getpid();
+	struct proc_fdinfo *fdinfo_buf = NULL;
+
+	sz = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, NULL, 0);
+	if (sz == 0)
+		return; /* no fds, really? */
+	else if (sz == -1)
+		goto fallback;
+	if ((fdinfo_buf = malloc(sz)) == NULL)
+		goto fallback;
+	r = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fdinfo_buf, sz);
+	if (r < 0 || r > sz)
+		goto fallback;
+	for (i = 0; i < r / (int)PROC_PIDLISTFD_SIZE; i++) {
+		if (fdinfo_buf[i].proc_fd >= lowfd)
+			close(fdinfo_buf[i].proc_fd);
+	}
+	free(fdinfo_buf);
+	return;
+ fallback:
+	free(fdinfo_buf);
+	closefrom_fallback(lowfd);
+	return;
+}
+#elif defined(HAVE_DIRFD) && defined(HAVE_PROC_PID)
+void
+closefrom(int lowfd)
+{
+    long fd;
+    char fdpath[PATH_MAX], *endp;
+    struct dirent *dent;
+    DIR *dirp;
+    int len;
+
+    /* Check for a /proc/$$/fd directory. */
+    len = snprintf(fdpath, sizeof(fdpath), "/proc/%ld/fd", (long)getpid());
+    if (len > 0 && (size_t)len < sizeof(fdpath) && (dirp = opendir(fdpath))) {
+	while ((dent = readdir(dirp)) != NULL) {
+	    fd = strtol(dent->d_name, &endp, 10);
+	    if (dent->d_name != endp && *endp == '\0' &&
+		fd >= 0 && fd < INT_MAX && fd >= lowfd && fd != dirfd(dirp))
+		(void) close((int) fd);
+	}
+	(void) closedir(dirp);
+	return;
+    }
+    /* /proc/$$/fd strategy failed, fall back to brute force closure */
+    closefrom_fallback(lowfd);
+}
+#else
+void
+closefrom(int lowfd)
+{
+	closefrom_fallback(lowfd);
+}
+#endif /* !HAVE_FCNTL_CLOSEM */
+#endif /* HAVE_CLOSEFROM */


### PR DESCRIPTION
Add support for building doas on macOS Catalina

- Adjust the Makefile and the README for macOS / Darwin specific build instructions
- Add bsd-closefrom.c as a more portable version of closefrom(2), which was obtained from the portable version of OpenSSH 8.1