### PR TITLE
Simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,68 +1,76 @@
-CC?=clang
-YACC?=yacc
-BIN=doas
-PREFIX?=/usr/local
-MANDIR?=$(DESTDIR)$(PREFIX)/man
-SYSCONFDIR?=$(DESTDIR)$(PREFIX)/etc
-OBJECTS=doas.o env.o compat/execvpe.o compat/reallocarray.o y.tab.o
-OPT?=-O2
+PREFIX     ?= /usr/local
+MANDIR     ?= $(DESTDIR)$(PREFIX)/man
+SYSCONFDIR ?= $(PREFIX)/etc
+
 # Can set GLOBAL_PATH here to set PATH for target user.
-# TARGETPATH=-DGLOBAL_PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:\"
-CFLAGS+=-Wall $(OPT) -DUSE_PAM -DDOAS_CONF=\"${SYSCONFDIR}/doas.conf\" $(TARGETPATH)
-CPPFLAGS+=-include compat/compat.h
-LDFLAGS+=-lpam
-UNAME_S := $(shell uname -s)
+# TARGETPATH = -DGLOBAL_PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:\"
+CPPFLAGS   += -include compat/compat.h
+CFLAGS     += -Wall \
+	      -DUSE_PAM \
+	      -DDOAS_CONF=\"$(SYSCONFDIR)/doas.conf\" \
+	      $(TARGETPATH)
+LDFLAGS    := -lpam $(LDFLAGS)
+
+UNAME_S    := $(shell uname -s)
+
+OBJS       = compat/execvpe.o \
+	     compat/reallocarray.o \
+	     doas.o \
+	     env.o \
+	     parse.o
+
 ifeq ($(UNAME_S),Linux)
-    LDFLAGS+=-lpam_misc
-    CPPFLAGS+=-Icompat
-    CFLAGS+=-D_GNU_SOURCE
-    COMPAT+=closefrom.o errc.o getprogname.o setprogname.o strlcat.o strlcpy.o strtonum.o verrc.o
-    OBJECTS+=$(COMPAT:%.o=compat/%.o)
-endif
-ifeq ($(UNAME_S),FreeBSD)
-    CFLAGS+=-DHAVE_LOGIN_CAP_H
-    LDFLAGS+=-lutil
-endif
-ifeq ($(UNAME_S),SunOS)
-    SAFE_PATH?=/bin:/sbin:/usr/bin:/usr/sbin:$(PREFIX)/bin:$(PREFIX)/sbin
-    GLOBAL_PATH?=/bin:/sbin:/usr/bin:/usr/sbin:$(PREFIX)/bin:$(PREFIX)/sbin
-    CPPFLAGS+=-Icompat
-    CFLAGS+=-DSOLARIS_PAM -DSAFE_PATH=\"$(SAFE_PATH)\" -DGLOBAL_PATH=\"$(GLOBAL_PATH)\"
-    COMPAT=errc.o pm_pam_conv.o setresuid.o verrc.o
-    OBJECTS+=$(COMPAT:%.o=compat/%.o)
-endif
-ifeq ($(UNAME_S),Darwin)
-    CPPFLAGS+=-Icompat
-    COMPAT+=bsd-closefrom.o
-    OBJECTS+=$(COMPAT:%.o=compat/%.o)
+    CPPFLAGS += -Icompat
+    CFLAGS   += -D_GNU_SOURCE
+    LDFLAGS  := -lpam_misc $(LDFLAGS)
+
+    OBJS     += compat/closefrom.o \
+		compat/errc.o \
+		compat/getprogname.o \
+		compat/setprogname.o \
+		compat/strlcat.o \
+		compat/strlcpy.o \
+		compat/strtonum.o \
+		compat/verrc.o
+
+else ifeq ($(UNAME_S),FreeBSD)
+    CFLAGS  += -DHAVE_LOGIN_CAP_H
+    LDFLAGS := -lutil $(LDFLAGS)
+
+else ifeq ($(UNAME_S),SunOS)
+    SAFE_PATH   ?= /bin:/sbin:/usr/bin:/usr/sbin:$(PREFIX)/bin:$(PREFIX)/sbin
+    GLOBAL_PATH ?= /bin:/sbin:/usr/bin:/usr/sbin:$(PREFIX)/bin:$(PREFIX)/sbin
+    CPPFLAGS    += -Icompat
+    CFLAGS      += -DSOLARIS_PAM -DSAFE_PATH=\"$(SAFE_PATH)\" -DGLOBAL_PATH=\"$(GLOBAL_PATH)\"
+
+    OBJS += compat/errc.o \
+	    compat/pm_pam_conv.o \
+	    compat/setresuid.o \
+	    compat/verrc.o
+
+else ifeq ($(UNAME_S),Darwin)
+    CPPFLAGS += -Icompat
+    OBJS     += compat/bsd-closefrom.o
     # On MacOS the default man page path is /usr/local/share/man
     MANDIR=$(DESTDIR)$(PREFIX)/share/man
+
 endif
 
-all: $(OBJECTS)
-	$(CC) -o $(BIN) $(OBJECTS) $(LDFLAGS)
+doas: $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(OBJS)
 
-env.o: doas.h env.c
+env.o: doas.h
+execvpe.o: doas.h
+doas.o: doas.h
+reallocarray.o: doas.h
 
-execvpe.o: doas.h execvpe.c
-
-doas.o: doas.h doas.c parse.y
-
-reallocarray.o: doas.h reallocarray.c
-
-y.tab.o: parse.y
-	$(YACC) parse.y
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c y.tab.c
-
-install: $(BIN)
+install: doas
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp $(BIN) $(DESTDIR)$(PREFIX)/bin/
-	chmod 4755 $(DESTDIR)$(PREFIX)/bin/$(BIN)
 	mkdir -p $(MANDIR)/man1
-	cp doas.1 $(MANDIR)/man1/
 	mkdir -p $(MANDIR)/man5
-	cp doas.conf.5 $(MANDIR)/man5/
+	install -m 4755 doas $(DESTDIR)$(PREFIX)/bin/doas
+	install -m 0444 doas.1 $(DESTDIR)$(MANDIR)/man1/doas.1
+	install -m 0444 doas.conf.5 $(DESTDIR)$(MANDIR)/man5/doas.conf.5
 
 clean:
-	rm -f $(BIN) $(OBJECTS) y.tab.c
-
+	$(RM) doas $(OBJS)


### PR DESCRIPTION
Leverage GNU Make's existing variables (`CC`, `YACC`) and builtin rules.
All text is reflowed to 80 columns to enhance readability.

LDFLAGS are set using `:=` as certain LDFLAGS can disable them from
being included properly (e.g -Wl,-O1…).