### PR TITLE
Add option for full login

### DIFF
--- a/doas.1
+++ b/doas.1
@@ -21,7 +21,7 @@
 .Nd execute commands as another user
 .Sh SYNOPSIS
 .Nm doas
-.Op Fl ns
+.Op Fl nSs
 .Op Fl a Ar style
 .Op Fl C Ar config
 .Op Fl u Ar user
@@ -35,7 +35,8 @@ utility executes the given command as another user.
 The
 .Ar command
 argument is mandatory unless
-.Fl C
+.Fl C ,
+.Fl S ,
 or
 .Fl s
 is specified.
@@ -72,6 +73,10 @@ No command is executed.
 Non interactive mode, fail if
 .Nm
 would prompt for password.
+.It Fl S
+Same as
+.Fl s
+but simulates a full login.
 .It Fl s
 Execute the shell from
 .Ev SHELL

--- a/doas.c
+++ b/doas.c
@@ -67,7 +67,7 @@ static struct pam_conv pamc = { pam_tty_conv, NULL };
 static void 
 usage(void)
 {
-	fprintf(stderr, "usage: doas [-ns] [-a style] [-C config] [-u user]"
+	fprintf(stderr, "usage: doas [-nSs] [-a style] [-C config] [-u user]"
 	    " command [args]\n");
 	exit(1);
 }
@@ -286,6 +286,7 @@ main(int argc, char **argv)
 	gid_t groups[NGROUPS_MAX + 1];
 	int ngroups;
 	int i, ch;
+	int Sflag = 0;
 	int sflag = 0;
 	int nflag = 0;
 	char cwdpath[PATH_MAX];
@@ -301,7 +302,7 @@ main(int argc, char **argv)
 
 	uid = getuid();
 
-	while ((ch = getopt(argc, argv, "a:C:nsu:")) != -1) {
+	while ((ch = getopt(argc, argv, "a:C:nSsu:")) != -1) {
 		switch (ch) {
                 #if defined(USE_BSD_AUTH)
 		case 'a':
@@ -324,6 +325,8 @@ main(int argc, char **argv)
 		case 'n':
 			nflag = 1;
 			break;
+		case 'S':
+			Sflag = 1;	
 		case 's':
 			sflag = 1;
 			break;
@@ -391,6 +394,10 @@ main(int argc, char **argv)
 		syslog(LOG_AUTHPRIV | LOG_NOTICE,
 		    "failed command for %s: %s", myname, cmdline);
 		errc(1, EPERM, NULL);
+	}
+
+	if (Sflag) {
+		argv[0] = "-doas";
 	}
 
 	if (!(rule->options & NOPASS)) {


### PR DESCRIPTION
This patch adds the _-S_ flag which is basically the same as _-s_, however it emulates a full (interactive) login rather than just starting a shell with redacted environment. This feature is in the spirit of _sudo -i_ and _su -l_, both of which provide this possibility. The "trick" simply is to start a shell with leading dash in argv[0].