### PR TITLE
doas: Use setusercontext(3) on NetBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ ifeq ($(UNAME_S),FreeBSD)
     CFLAGS+=-DHAVE_LOGIN_CAP_H
     LDFLAGS+=-lutil
 endif
+ifeq ($(UNAME_S),NetBSD)
+    CFLAGS+=-DHAVE_LOGIN_CAP_H -D_OPENBSD_SOURCE
+    OBJECTS=doas.o env.o y.tab.o
+    LDFLAGS+=-lutil
+endif
 ifeq ($(UNAME_S),SunOS)
     SAFE_PATH?=/bin:/sbin:/usr/bin:/usr/sbin:$(PREFIX)/bin:$(PREFIX)/sbin
     GLOBAL_PATH?=/bin:/sbin:/usr/bin:/usr/sbin:$(PREFIX)/bin:$(PREFIX)/sbin

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -13,7 +13,9 @@ extern const char *__progname;
 
 const char *getprogname(void);
 
+#if !defined(__NetBSD__)
 void *reallocarray(void *optr, size_t nmemb, size_t size);
+#endif
 
 void setprogname(const char *progname);
 


### PR DESCRIPTION
Calling setusercontext(3) makes per-user temporary storage work (see
per_user_tmp in security(7) and rc.conf(5)).

May as well also use reallocarray(3) from libc instead of the bundled
compat code.