### PR TITLE
Avoid unnecessary doas.conf race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
-AWK?=awk
+SED?=sed
 CC?=clang
 YACC?=yacc
 BIN=doas
 PREFIX?=/usr/local
 MANDIR?=$(DESTDIR)$(PREFIX)/man
 SYSCONFDIR?=$(DESTDIR)$(PREFIX)/etc
+DOAS_CONF=$(SYSCONFDIR)/doas.conf
 OBJECTS=doas.o env.o compat/execvpe.o compat/reallocarray.o y.tab.o 
 OPT?=-O2
 # Can set GLOBAL_PATH here to set PATH for target user.
 # TARGETPATH=-DGLOBAL_PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:\"
-CFLAGS+=-Wall $(OPT) -DUSE_PAM -DDOAS_CONF=\"${SYSCONFDIR}/doas.conf\" $(TARGETPATH)
+CFLAGS+=-Wall $(OPT) -DUSE_PAM -DDOAS_CONF=\"$(DOAS_CONF)\" $(TARGETPATH)
 CPPFLAGS+=-include compat/compat.h
 LDFLAGS+=-lpam
 UNAME_S := $(shell uname -s)
@@ -45,7 +46,9 @@ ifeq ($(UNAME_S),Darwin)
     MANDIR=$(DESTDIR)$(PREFIX)/share/man
 endif
 
-all: $(OBJECTS) doas.1.final doas.conf.5.final
+all: $(BIN) doas.1.final doas.conf.5.final vidoas.final
+
+$(BIN): $(OBJECTS)
 	$(CC) -o $(BIN) $(OBJECTS) $(LDFLAGS)
 
 env.o: doas.h env.c
@@ -60,11 +63,12 @@ y.tab.o: parse.y
 	$(YACC) parse.y
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c y.tab.c
 
-install: $(BIN)
+install: $(BIN) vidoas.final
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp $(BIN) $(DESTDIR)$(PREFIX)/bin/
-	cp vidoas $(DESTDIR)$(PREFIX)/bin/
 	chmod 4755 $(DESTDIR)$(PREFIX)/bin/$(BIN)
+	cp vidoas.final $(DESTDIR)$(PREFIX)/bin/vidoas
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/vidoas
 	mkdir -p $(MANDIR)/man1
 	cp doas.1.final $(MANDIR)/man1/doas.1
 	mkdir -p $(MANDIR)/man5
@@ -82,8 +86,11 @@ clean:
 
 # Doing it this way allows to change the original files
 # only partially instead of renaming them.
-doas.1.final:
-	$(AWK) -v pfx="$(SYSCONFDIR)" '{gsub("@SUBSTSYSCONFDIR@",pfx); print $$0}' < doas.1 > doas.1.final
+doas.1.final: doas.1
+	$(SED) 's,@DOAS_CONF@,$(DOAS_CONF),g' < $< > $@
 
-doas.conf.5.final:
-	$(AWK) -v pfx="$(SYSCONFDIR)" '{gsub("@SUBSTSYSCONFDIR@",pfx); print $$0}' < doas.conf.5 > doas.conf.5.final
+doas.conf.5.final: doas.conf.5
+	$(SED) 's,@DOAS_CONF@,$(DOAS_CONF),g' < $< > $@
+
+vidoas.final: vidoas
+	$(SED) 's,@DOAS_CONF@,$(DOAS_CONF),g' < $< > $@

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ y.tab.o: parse.y
 	$(YACC) parse.y
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c y.tab.c
 
-install: $(BIN) vidoas.final
+install: $(BIN) doas.1.final doas.conf.5.final vidoas.final
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp $(BIN) $(DESTDIR)$(PREFIX)/bin/
 	chmod 4755 $(DESTDIR)$(PREFIX)/bin/$(BIN)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CAT?=cat
 SED?=sed
 CC?=clang
 YACC?=yacc
@@ -87,10 +88,7 @@ clean:
 # Doing it this way allows to change the original files
 # only partially instead of renaming them.
 doas.1.final: doas.1
-	$(SED) 's,@DOAS_CONF@,$(DOAS_CONF),g' < $< > $@
-
 doas.conf.5.final: doas.conf.5
-	$(SED) 's,@DOAS_CONF@,$(DOAS_CONF),g' < $< > $@
-
 vidoas.final: vidoas
-	$(SED) 's,@DOAS_CONF@,$(DOAS_CONF),g' < $< > $@
+doas.1.final doas.conf.5.final vidoas.final:
+	$(CAT) $^ | $(SED) 's,@DOAS_CONF@,$(DOAS_CONF),g' > $@

--- a/doas.1
+++ b/doas.1
@@ -96,7 +96,7 @@ It may fail for one of the following reasons:
 .Bl -bullet -compact
 .It
 The config file
-.Pa @SUBSTSYSCONFDIR@/doas.conf
+.Pa @DOAS_CONF@
 could not be parsed.
 .It
 The user attempted to run a command which is not permitted.

--- a/doas.conf.5
+++ b/doas.conf.5
@@ -20,7 +20,7 @@
 .Nm doas.conf
 .Nd doas configuration file
 .Sh SYNOPSIS
-.Nm @SUBSTSYSCONFDIR@/doas.conf
+.Nm @DOAS_CONF@
 .Sh DESCRIPTION
 The
 .Xr doas 1

--- a/vidoas
+++ b/vidoas
@@ -1,8 +1,6 @@
 #!/bin/sh
-
-# This script edits a temporary copy of the doas.conf file and
-# automatically checks it for syntax errors before installing
-# the new copy of doas.conf.
+# Edit a temporary copy of the doas.conf file and check it for syntax
+# errors before installing it as the actual doas.conf file.
 
 set -eu
 
@@ -11,15 +9,10 @@ export PATH
 
 PROG="${0##*/}"
 
-umask 077
+umask 022
 
-WRK_DIR=/var/tmp
-INSTALL_DIR=/usr/local/etc
-
-doas_conf_mode=0644
-
-doas_lock_file="${WRK_DIR}/doas.conf"
-installed_doas="${INSTALL_DIR}/doas.conf"
+DOAS_CONF=@DOAS_CONF@
+doas_lock_file="${DOAS_CONF}.lck"
 
 die()
 {
@@ -58,27 +51,48 @@ set_trap_rm()
     fi
 }
 
-tmp_doas="$(mktemp "${WRK_DIR}/doas.conf.XXXXXXXXXX")"
+tmp_doas="$(mktemp "${DOAS_CONF}.XXXXXXXXXX")" \
+|| die "You probably need to run ${PROG} as root"
 set_trap_rm "${tmp_doas}"
 
-# Check to see if an existing configuration file is installed.
-if [ -f "${installed_doas}" ]
+# It is important that the ln(1) command fails if the target already
+# exists.  Some versions are known to behave like "ln -f" by default
+# (removing any existing target).  Adjust PATH to avoid such ln(1)
+# implementations.
+
+tmp_test_ln="$(mktemp "${DOAS_CONF}.XXXXXXXXXX")"
+set_trap_rm "${tmp_doas}" "${tmp_test_ln}"
+
+if ln "${tmp_doas}" "${tmp_test_ln}" 2>/dev/null
 then
-    if [ -r "${installed_doas}" ]
+    die 'ln(1) is not safe for lock files, bailing'
+fi
+
+# If a doas.conf file exists, copy it into the temporary file for
+# editing.  If none exist, the editor will open with an empty file.
+
+if [ -f "${DOAS_CONF}" ]
+then
+    if [ -r "${DOAS_CONF}" ]
     then
-	cp "${installed_doas}" "${tmp_doas}"
+	cp "${DOAS_CONF}" "${tmp_doas}"
     else
-	die "Cannot read ${installed_doas}"
+	die "Cannot read ${DOAS_CONF}"
     fi
 fi
 
-# Check to see if existing temporary doas.conf file exists.
+# Link the temporary file to the lock file.
+
 if ln "${tmp_doas}" "${doas_lock_file}"
 then
-    set_trap_rm "${tmp_doas}" "${doas_lock_file}"
+    set_trap_rm "${tmp_doas}" "${tmp_test_ln}" "${doas_lock_file}"
 else
-    die "The doas.conf file is already locked"
+    die "${DOAS_CONF} is already locked"
 fi
+
+# Some versions of vi(1) exit with a code that reflects the number of
+# editing errors made.  This is why we ignore the exit code from the
+# editor.
 
 "${EDITOR:-vi}" "${tmp_doas}" || true
 
@@ -90,18 +104,21 @@ do
     "${EDITOR:-vi}" "${tmp_doas}" || true
 done
 
+# Use mv(1) to rename the temporary file to doas.conf as it is atomic.
+# This avoids any problems from another process reading doas.conf while
+# it is being written.
+
 if [ -s "${tmp_doas}" ]
 then
-    if cmp -s "${tmp_doas}" "${installed_doas}"
+    if cmp -s "${tmp_doas}" "${DOAS_CONF}"
     then
 	warn "No changes made"
-	warn "${installed_doas} unchanged"
+	warn "${DOAS_CONF} unchanged"
     else
-	doas -- install -m "${doas_conf_mode}" \
-	    "${tmp_doas}" "${installed_doas}" \
-	&& warn "${installed_doas} updated"
+	mv "${tmp_doas}" "${DOAS_CONF}" \
+	&& warn "${DOAS_CONF} updated"
     fi
 else
     warn "Not installing an empty doas.conf file"
-    warn "${installed_doas} unchanged"
+    warn "${DOAS_CONF} unchanged"
 fi


### PR DESCRIPTION
Avoid an unnecessary race with the *doas.conf* file by using **mv(1)** to install it. This fixes the remaining fallout from #46.

Simultaneously made some changes to improve maintenance:
- Define the `DOAS_CONF` path in one place only (i.e. in *Makefile*). This also addresses the outstanding TODO from #46.
- Avoid unnecessary rebuilding of the *doas* binary.
- Add missing dependencies for the `install` target.
