### PR TITLE
Add Fedora build dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ The doas command is in FreeBSD's ports collection and may be installed by simply
 #### Debian and Ubuntu based distributions
 
      sudo apt install build-essential make bison flex libpam0g-dev 
+
+#### Fedora
+
+     sudo dnf install gcc gcc-c++ kernel-devel make flex bison bison-devel flex-devel pam-devel byacc
     
 #### macOS
 


### PR DESCRIPTION
Tested on Fedora 33 Workstation:

Notes:
- `gcc gcc-c++ kernel-devel make` and can be replaced with `dnf groupinstall "Development Tools"`
- Theoretically, `yum` should also work with same package names, but I have not tested that.