### PR TITLE
Fixed/Added, after tests, CentOS and Fedora build dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,19 @@ The doas command is in FreeBSD's ports collection and may be installed by simply
 
      sudo apt install build-essential make bison flex libpam0g-dev 
 
-#### Fedora
 
-     sudo dnf install gcc gcc-c++ kernel-devel make flex bison bison-devel flex-devel pam-devel byacc
-    
+### Fedora
+
+      sudo dnf install gcc gcc-c++ make flex bison pam-devel byacc
+
+### CentOS 8 and Stream
+
+      sudo dnf install gcc gcc-c++ make flex bison pam-devel byacc git
+
+### CentOS 7.x
+
+      sudo yum install gcc gcc-c++ make flex bison pam-devel byacc git
+
 #### macOS
 
      xcode-select --install


### PR DESCRIPTION
Not all packages installed by the updated DNF command line are needed. Added CentOS, YUM and DNF, build dependencies also.
I did the tests with _toolbox_ with Fedora 31,32,33 and even 34 containers and with _podman_ for CentOS 7.x, 8 and Stream.

Some for reference:
https://github.com/slicer69/doas/pull/73#issuecomment-778646343
https://github.com/slicer69/doas/pull/73#issuecomment-778650670
https://github.com/slicer69/doas/pull/73#commitcomment-47090128
https://github.com/slicer69/doas/commit/1050ff4a5a74ad1927a38da0a65dfce4234cd182#commitcomment-47090128