### PR TITLE
doasedit: fallback to EDITOR if VISUAL fails

### DIFF
--- a/doasedit
+++ b/doasedit
@@ -44,13 +44,21 @@ then
    exit 5
 fi
 
-"${EDITOR:-vi}" "$temp_file"
+# If $VISUAL fails, run $EDITOR.
+# $EDITOR should be a line editor functional without advanced terminal features.
+# $VISUAL is a more advanced editor such as vi.
+"${VISUAL:-vi}" "$temp_file"
 if [ ! $? ]
 then
-  echo "Could not run editor $EDITOR"
-  echo "Please make sure EDITOR variable is set."
-  rm -f "$temp_file"
-  exit 6
+    "${EDITOR:-ex}" "$temp_file"
+    if [ ! $? ]
+    then
+      echo "Could not run visual editor $VISUAL"
+      echo "Could not run editor $EDITOR"
+      echo "Please make sure the VISUAL and/or EDITOR variables are set."
+      rm -f "$temp_file"
+      exit 6
+    fi
 fi
 
 # Check to see if the file has been changed.

--- a/doasedit.8
+++ b/doasedit.8
@@ -36,7 +36,8 @@ to run their text editor as the super user.
 .Pp
 The doasedit utility accepts one argument, the file to
 be edited. The text editor used during the editing process
-is set using the EDITOR environment variable.
+is set using the VISUAL environment variable. If VISUAL fails
+to run, EDITOR is tried instead.
 .El
 .Sh EXIT STATUS
 .Ex -std


### PR DESCRIPTION
VISUAL is usually a full screen editor such as `vi`, while EDITOR is supposed to work on a teletype terminal. Although this compatibility is not as important today, it may be useful if the terminal is malfunctioning (such as when an ssh server does not have the terminfo of the client's terminal).