### PR TITLE
remove obsolete initialization

### DIFF
--- a/doas.c
+++ b/doas.c
@@ -321,7 +321,6 @@ main(int argc, char **argv)
 			exit(i != -1);
 */
 		case 'u':
-                        targetname[0] = '\0';
 			if (strlcpy(targetname, optarg, sizeof(targetname)) >= sizeof(targetname))
 				errx(1, "pw_name too long");
 			if (parseuid(targetname, &target) != 0)


### PR DESCRIPTION
This initializer is obsolete as targetname is initialized just prior the while loop and not touched elsewhere within the loop.