### PR TITLE
Fix compilation on Linux

### DIFF
--- a/doas.c
+++ b/doas.c
@@ -420,7 +420,7 @@ main(int argc, char **argv)
 		pam_handle_t *pamh = NULL;
 		int pam_err;
 
-/* #ifndef linux */
+/* #ifndef __linux__ */
 		int temp_stdin;
 
 		/* openpam_ttyconv checks if stdin is a terminal and
@@ -497,7 +497,7 @@ main(int argc, char **argv)
 		}
 		pam_end(pamh, pam_err);
 
-#ifndef linux
+#ifndef __linux__
 		/* Re-establish stdin */
 		if (dup2(temp_stdin, STDIN_FILENO) == -1)
 			err(1, "dup2");

--- a/env.c
+++ b/env.c
@@ -135,7 +135,7 @@ createenv(struct rule *rule, struct passwd *original, struct passwd *target)
 	addnode(env, "USER", target->pw_name);
 
 	if (rule->options & KEEPENV) {
-                #ifndef linux
+                #ifndef __linux__
 		extern const char **environ;
                 #endif
 


### PR DESCRIPTION
Symptom with GCC 11:
> ```
> gcc-11 -std=c99 -Wextra -pedantic -Wall -O2 -DUSE_PAM -DDOAS_CONF=\"/etc/doas.conf\"  -D_GNU_SOURCE -include compat/compat.h -Icompat  -c -o env.o env.c
> env.c: In function ‘createenv’:
> env.c:139:37: error: conflicting types for ‘environ’; have ‘const char **’
>   139 |                 extern const char **environ;
>       |                                     ^~~~~~~
> ```

Symptom with Clang 17:
> ```
> clang-17 -std=c99 -Wextra -pedantic -Wall -O2 -DUSE_PAM -DDOAS_CONF=\"/etc/doas.conf\"  -D_GNU_SOURCE -include compat/compat.h -Icompat  -c -o env.o env.c
> env.c:139:23: error: redeclaration of 'environ' with a different type: 'const char **' vs 'char **'
>                 extern const char **environ;
>                                     ^
> ```

Related:
https://sourceforge.net/p/predef/wiki/OperatingSystems/#linux-kernel