### PR TITLE
Improve macOS build instructions in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,21 @@ The doas command may be installed from [Pacstall](https://github.com/pacstall/pa
 
      make
     
-#### FreeBSD, MidnightBSD, NetBSD and macOS
+#### FreeBSD, MidnightBSD, NetBSD
 
      gmake
+
+#### macOS
+
+To build `doas`, you'll also have to install and symlink `byacc`:
+
+    brew install byacc    
+    ln -s /opt/homebrew/bin/byacc /opt/homebrew/bin/yacc
+    export PATH="/opt/homebrew/bin/yacc:$PATH"
+
+Then you can simply run `make` or `gmake`:
+
+     make
 
 #### illumos
 

--- a/README.md
+++ b/README.md
@@ -111,21 +111,19 @@ After you save this file you may need to reboot in order for the change to take 
 
 #### macOS
 
-To build `doas`, you'll need to have Xcode Command Line Tools, as well as
-install and symlink `byacc`:
+To build `doas`, you'll need to have Xcode Command Line Tools, and use `bison`
+instead of `byacc`:
 
-    brew install byacc
-    ln -s /opt/homebrew/bin/byacc /opt/homebrew/bin/yacc
-    export PATH="/opt/homebrew/bin/yacc:$PATH"
+    YACC='bison -y' PREFIX=/opt/local make
 
 Alternatively, if you have Xcode.app installed, you can just:
 
     xcode-select --switch /Applications/Xcode.app/Contents/Developer
-    gmake install
+    make
 
-Then you can simply run `make` or `gmake`:
+Lastly, run the following:
 
-     make
+     make install
      cp /etc/pam.d/sudo /etc/pam.d/doas
 
 Note: By default macOS blocks doas from using PAM modules, causing doas authentication to fail. The cp command above copies the sudo PAM configuration into place for doas to use.

--- a/README.md
+++ b/README.md
@@ -75,18 +75,6 @@ The doas command may be installed from [Pacstall](https://github.com/pacstall/pa
 
      gmake
 
-#### macOS
-
-To build `doas`, you'll also have to install and symlink `byacc`:
-
-    brew install byacc    
-    ln -s /opt/homebrew/bin/byacc /opt/homebrew/bin/yacc
-    export PATH="/opt/homebrew/bin/yacc:$PATH"
-
-Then you can simply run `make` or `gmake`:
-
-     make
-
 #### illumos
 
      PREFIX=/opt/local gmake
@@ -123,8 +111,21 @@ After you save this file you may need to reboot in order for the change to take 
 
 #### macOS
 
-     xcode-select --switch /Applications/Xcode.app/Contents/Developer
-     gmake install
+To build `doas`, you'll need to have Xcode Command Line Tools, as well as
+install and symlink `byacc`:
+
+    brew install byacc
+    ln -s /opt/homebrew/bin/byacc /opt/homebrew/bin/yacc
+    export PATH="/opt/homebrew/bin/yacc:$PATH"
+
+Alternatively, if you have Xcode.app installed, you can just:
+
+    xcode-select --switch /Applications/Xcode.app/Contents/Developer
+    gmake install
+
+Then you can simply run `make` or `gmake`:
+
+     make
      cp /etc/pam.d/sudo /etc/pam.d/doas
 
 Note: By default macOS blocks doas from using PAM modules, causing doas authentication to fail. The cp command above copies the sudo PAM configuration into place for doas to use.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The doas utility is a program originally written for OpenBSD which allows a user
 
 The doas program offers two benefits over sudo: its configuration file has a simple syntax and it is smaller, requiring less effort to audit the code. This makes it harder for both admins and coders to make mistakes that potentially open security holes in the system.
 
-This port of doas has been made to work on FreeBSD 11.x and newer, most distributions of Linux, NetBSD 8.x and newer, and most illumos distributions (tested on OmniOS and SmartOS). It also works on macOS Catalina.
+This port of doas has been made to work on FreeBSD 11.x and newer, most distributions of Linux, NetBSD 8.x and newer, and most illumos distributions (tested on OmniOS and SmartOS). It also works on macOS Sonoma.
 
 Installing doas is accomplished in three steps:
 


### PR DESCRIPTION
Fixes https://github.com/slicer69/doas/issues/133

- Documents a working solution to build `doas` on macOS.
- `yacc` is removed from latest Xcode Command Line Tools.
- We can select `bison` at build-time using `YACC='bison -y'` instead.