### PR TITLE
Fix(mdoc): section number 1 -> 8 on `.Dt`

### DIFF
--- a/doasedit.8
+++ b/doasedit.8
@@ -16,7 +16,7 @@
 .\" PERFORMANCE OF THIS SOFTWARE.
 .\"
 .Dd September 13, 2021
-.Dt DOASEDIT 1
+.Dt DOASEDIT 8
 .Os
 .Sh NAME
 .Nm doasedit

--- a/vidoas.8
+++ b/vidoas.8
@@ -16,7 +16,7 @@
 .\" PERFORMANCE OF THIS SOFTWARE.
 .\"
 .Dd November 9, 2020
-.Dt VIDOAS 1
+.Dt VIDOAS 8
 .Os
 .Sh NAME
 .Nm vidoas


### PR DESCRIPTION
Previously, section number on `.Dt` field was mismatching with its filename `doasedit.8` and `vidoas.8`.